### PR TITLE
Fix NPE in DefaultResultSetCollector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.iml
+.idea/
+target/

--- a/log4jdbc-log4j2-jdbc4.1/src/main/java/net/sf/log4jdbc/sql/resultsetcollector/DefaultResultSetCollector.java
+++ b/log4jdbc-log4j2-jdbc4.1/src/main/java/net/sf/log4jdbc/sql/resultsetcollector/DefaultResultSetCollector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -35,10 +35,11 @@ public class DefaultResultSetCollector implements ResultSetCollector {
   private boolean fillInUnreadValues = false;
 
   public DefaultResultSetCollector(boolean fillInUnreadValues) {
-	  this.reset();
-      this.fillInUnreadValues = fillInUnreadValues;
-      this.lastValueReturnedByNext = true;
+    this.reset();
+    this.fillInUnreadValues = fillInUnreadValues;
+    this.lastValueReturnedByNext = true;
   }
+
   /**
    * A {@code boolean} defining whether parameters of this {@code DefaultResultSetColector}
    * has already been obtained from a {@code ResultSetMetaData}.
@@ -94,12 +95,12 @@ public class DefaultResultSetCollector implements ResultSetCollector {
   private Map<String, Integer> colNameToColIndex;
   private int colIndex;
   //same getters in JDBC 4.2
-  private static final List<String> GETTERS = Arrays.asList(new String[] {"getArray",
-          "getAsciiStream", "getBigDecimal", "getBinaryStream", "getBlob", "getBoolean",
-          "getByte", "getBytes", "getCharacterStream", "getClob", "getDate", "getDouble",
-          "getFloat", "getInt", "getLong", "getNCharacterStream", "getNClob", "getNString",
-          "getObject", "getRef", "getRowId", "getShort", "getSQLXML", "getString",
-          "getTime", "getTimestamp", "getUnicodeStream", "getURL"});
+  private static final List<String> GETTERS = Arrays.asList(new String[]{"getArray",
+      "getAsciiStream", "getBigDecimal", "getBinaryStream", "getBlob", "getBoolean",
+      "getByte", "getBytes", "getCharacterStream", "getClob", "getDate", "getDouble",
+      "getFloat", "getInt", "getLong", "getNCharacterStream", "getNClob", "getNString",
+      "getObject", "getRef", "getRowId", "getShort", "getSQLXML", "getString",
+      "getTime", "getTimestamp", "getUnicodeStream", "getURL"});
 
   public List<List<Object>> getRows() {
     return rows;
@@ -122,75 +123,78 @@ public class DefaultResultSetCollector implements ResultSetCollector {
 
   @Override
   public void loadMetaDataIfNeeded(ResultSet rs) {
-	  //if data already loaded
-	  if (this.loaded) {
-		  return;
-	  }
-	  //otherwise, get all data now, so that we don't need
-	  //to use the ResultSetMetaData later (with some drivers,
-	  //it cannot be used once the ResultSet has been closed)
-      try {
-    	  if (!rs.isClosed()) {
-    		  this.loadMetaDataIfNeeded(rs.getMetaData());
-    	  }
-      } catch (SQLException e) {
-        throw new RuntimeException(e);
+    //if data already loaded
+    if (this.loaded) {
+      return;
+    }
+    //otherwise, get all data now, so that we don't need
+    //to use the ResultSetMetaData later (with some drivers,
+    //it cannot be used once the ResultSet has been closed)
+    try {
+      if (!rs.isClosed()) {
+        this.loadMetaDataIfNeeded(rs.getMetaData());
       }
-      this.loaded = true;
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+    this.loaded = true;
   }
 
   /**
    * Perform the operations requested by {@link #loadMetaDataIfNeeded(ResultSet)},
    * using directly the related <code>ResultSetMetaData</code>.
-   * @param metaData 	The <code>ResultSetMetaData</code> through which the information
+   * @param metaData        The <code>ResultSetMetaData</code> through which the information
    * 					needed by {@link #loadMetaDataIfNeeded(ResultSet)} are obtained.
    */
-  private void loadMetaDataIfNeeded(ResultSetMetaData metaData)
-  {
-	  //if data already loaded
-	  if (this.loaded) {
-		  return;
-	  }
-	  //otherwise, get all data now, so that we don't need
-	  //to use the ResultSetMetaData later (with some drivers,
-	  //it cannot be used once the ResultSet has been closed)
-      try {
-          if (metaData == null) {
-              this.columnCount = 0;
-          } else {
-    	      this.columnCount = metaData.getColumnCount();
-          }
-    	  this.colNameToColIndex = new HashMap<String, Integer>(this.columnCount);
-    	  for (int column = 1; column <= this.columnCount; column++) {
-    		  String label = metaData.getColumnLabel(column).toLowerCase();
-    		  String name  = metaData.getColumnName(column).toLowerCase();
-    		  this.columnLabels.put(column, label);
-    		  this.columnNames.put(column, name);
-    		  colNameToColIndex.put(label, column);
-    		  colNameToColIndex.put(name, column);
-    		  //get also the table name to resolve calls such as:
-    		  //rs.getString("myTable.myColumn")
-            String tableName = metaData.getTableName(column);
-            if (tableName != null) {
-              String table = tableName.toLowerCase();
-              colNameToColIndex.put(table + "." + name, column);
-              //not sure whether table name can be mixed with column label,
-              //but just in case...
-              colNameToColIndex.put(table + "." + label, column);
-            }
-    	  }
-    	  this.loaded = true;
-      } catch (SQLException e) {
-        throw new RuntimeException(e);
+  private void loadMetaDataIfNeeded(ResultSetMetaData metaData) {
+    //if data already loaded
+    if (this.loaded) {
+      return;
+    }
+    //otherwise, get all data now, so that we don't need
+    //to use the ResultSetMetaData later (with some drivers,
+    //it cannot be used once the ResultSet has been closed)
+    try {
+      if (metaData == null) {
+        this.columnCount = 0;
+      } else {
+        this.columnCount = metaData.getColumnCount();
       }
+      this.colNameToColIndex = new HashMap<String, Integer>(this.columnCount);
+      for (int column = 1; column <= this.columnCount; column++) {
+        String columnLabel = metaData.getColumnLabel(column);
+        String columnName = metaData.getColumnName(column);
+        if (columnLabel != null && columnName != null) {
+          String label = columnLabel.toLowerCase();
+          String name = columnName.toLowerCase();
+          this.columnLabels.put(column, label);
+          this.columnNames.put(column, name);
+          colNameToColIndex.put(label, column);
+          colNameToColIndex.put(name, column);
+          //get also the table name to resolve calls such as:
+          //rs.getString("myTable.myColumn")
+          String tableName = metaData.getTableName(column);
+          if (tableName != null) {
+            String table = tableName.toLowerCase();
+            colNameToColIndex.put(table + "." + name, column);
+            //not sure whether table name can be mixed with column label,
+            //but just in case...
+            colNameToColIndex.put(table + "." + label, column);
+          }
+        }
+      }
+      this.loaded = true;
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public String getColumnName(int column) {
-      return this.columnNames.get(column);
+    return this.columnNames.get(column);
   }
 
   public String getColumnLabel(int column) {
-	  return this.columnLabels.get(column);
+    return this.columnLabels.get(column);
   }
 
   /*
@@ -202,8 +206,7 @@ public class DefaultResultSetCollector implements ResultSetCollector {
    */
   @Override
   public boolean methodReturned(ResultSetSpy resultSetSpy, String methodCall, Object returnValue,
-		  Object targetObject, Object... methodParams)
-  {
+                                Object targetObject, Object... methodParams) {
 
     if (methodCall.startsWith("get") && methodParams != null && methodParams.length == 1) {
 
@@ -220,16 +223,16 @@ public class DefaultResultSetCollector implements ResultSetCollector {
       }
     }
     if ("next()".equals(methodCall) || "first()".equals(methodCall)) {
-    	this.lastValueReturnedByNext = (Boolean) returnValue;
+      this.lastValueReturnedByNext = (Boolean) returnValue;
     }
     if ("next()".equals(methodCall) || "first()".equals(methodCall) ||
-    		"close()".equals(methodCall)) {
+        "close()".equals(methodCall)) {
       loadMetaDataIfNeeded(resultSetSpy.getRealResultSet());
       boolean isEndOfResultSet =
-    		  //"close" triggers a printing only if the previous call to next
-    		  //did not return false (end of result set already reached)
-    		  ("close()".equals(methodCall) && this.lastValueReturnedByNext != false) ||
-    		  Boolean.FALSE.equals(returnValue) ;
+          //"close" triggers a printing only if the previous call to next
+          //did not return false (end of result set already reached)
+          ("close()".equals(methodCall) && this.lastValueReturnedByNext != false) ||
+              Boolean.FALSE.equals(returnValue);
       if (row != null) {
         if (rows == null)
           rows = new ArrayList<List<Object>>();
@@ -284,7 +287,7 @@ public class DefaultResultSetCollector implements ResultSetCollector {
   @Override
   public void preMethod(ResultSetSpy resultSetSpy, String methodCall, Object... methodParams) {
     if ((methodCall.equals("next()") || methodCall.equals("close()")) &&
-    		fillInUnreadValues) {
+        fillInUnreadValues) {
       if (row != null) {
         int colIndex = 0;
         for (Object v : row) {
@@ -292,11 +295,11 @@ public class DefaultResultSetCollector implements ResultSetCollector {
             Object resultSetValue = null;
             try {
               // Fill in any unread data
-              resultSetValue = JdbcUtils.getResultSetValue(resultSetSpy.getRealResultSet(),colIndex+1);
+              resultSetValue = JdbcUtils.getResultSetValue(resultSetSpy.getRealResultSet(), colIndex + 1);
             } catch (SQLException e) {
               resultSetValue = UNREAD_ERROR;
             }
-            if (resultSetValue!=null) {
+            if (resultSetValue != null) {
               row.set(colIndex, resultSetValue);
             } else {
               row.set(colIndex, NULL_RESULT_SET_VAL);

--- a/log4jdbc-log4j2-jdbc4.1/src/main/java/net/sf/log4jdbc/sql/resultsetcollector/DefaultResultSetCollector.java
+++ b/log4jdbc-log4j2-jdbc4.1/src/main/java/net/sf/log4jdbc/sql/resultsetcollector/DefaultResultSetCollector.java
@@ -40,65 +40,65 @@ public class DefaultResultSetCollector implements ResultSetCollector {
       this.lastValueReturnedByNext = true;
   }
   /**
-   * A {@code boolean} defining whether parameters of this {@code DefaultResultSetColector} 
+   * A {@code boolean} defining whether parameters of this {@code DefaultResultSetColector}
    * has already been obtained from a {@code ResultSetMetaData}.
    */
   private boolean loaded;
   /**
-   * An <code>int</code> representing the number of columns 
-   * in the real <code>ResultSet</code> object, obtained by calling 
+   * An <code>int</code> representing the number of columns
+   * in the real <code>ResultSet</code> object, obtained by calling
    * <code>getColumnCount</code> on the related <code>ResultSetMetaData</code> object.
-   * This attribute is an <code>Integer</code> rather than an <code>int</code>, 
-   * so that we can distinguish the case where the column count has not yet been obtained, 
+   * This attribute is an <code>Integer</code> rather than an <code>int</code>,
+   * so that we can distinguish the case where the column count has not yet been obtained,
    * from the case when the column count is 0 (should never happend, but still...)
    */
   private int columnCount;
   /**
-   * A <code>Map</code> where the key is an <code>Integer</code> representing 
-   * the index of a column, and the corresponding value is a <code>String</code> 
-   * being the label of the column. 
-   * This <code>Map</code> is populated by calling <code>getColumnLabel</code> 
-   * on the <code>ResultSetMetaData</code> object of the real <code>ResultSet</code> object, 
+   * A <code>Map</code> where the key is an <code>Integer</code> representing
+   * the index of a column, and the corresponding value is a <code>String</code>
+   * being the label of the column.
+   * This <code>Map</code> is populated by calling <code>getColumnLabel</code>
+   * on the <code>ResultSetMetaData</code> object of the real <code>ResultSet</code> object,
    * for each column (see {@link #columnCount}).
    */
   private Map<Integer, String> columnLabels;
   /**
-   * A <code>Map</code> where the key is an <code>Integer</code> representing 
-   * the index of a column, and the corresponding value is a <code>String</code> 
-   * being the name of the column. 
-   * This <code>Map</code> is populated by calling <code>getColumnLabel</code> 
-   * on the <code>ResultSetMetaData</code> object of the real <code>ResultSet</code> object, 
+   * A <code>Map</code> where the key is an <code>Integer</code> representing
+   * the index of a column, and the corresponding value is a <code>String</code>
+   * being the name of the column.
+   * This <code>Map</code> is populated by calling <code>getColumnLabel</code>
+   * on the <code>ResultSetMetaData</code> object of the real <code>ResultSet</code> object,
    * for each column (see {@link #columnCount}).
    */
   private Map<Integer, String> columnNames;
   /**
-   * A <code>boolean</code> that is the last value returned by a call 
-   * to <code>next</code> (or <code>first</code>) on the related <code>ResultSet</code>. 
-   * This allows to know if this <code>ResultSetCollector</code> must be printed 
-   * when <code>close</code> is called on the related <code>ResultSet</code>: 
-   * if the previous call to <code>next</code> returned <code>true</code>, 
-   * then this <code>ResultSetCollector</code> must be printed 
-   * on the call to <code>close</code>; otherwise, it was already printed following 
-   * the previous call to <code>next</code>, and should not be printed 
+   * A <code>boolean</code> that is the last value returned by a call
+   * to <code>next</code> (or <code>first</code>) on the related <code>ResultSet</code>.
+   * This allows to know if this <code>ResultSetCollector</code> must be printed
+   * when <code>close</code> is called on the related <code>ResultSet</code>:
+   * if the previous call to <code>next</code> returned <code>true</code>,
+   * then this <code>ResultSetCollector</code> must be printed
+   * on the call to <code>close</code>; otherwise, it was already printed following
+   * the previous call to <code>next</code>, and should not be printed
    * on the call to <code>close</code>.
    * <p>
-   * This attribute must not be reset after a printing (the other attributes are, through a call 
-   * to <code>reset</code>), in case the related <code>ResultSet</code> is reused. 
+   * This attribute must not be reset after a printing (the other attributes are, through a call
+   * to <code>reset</code>), in case the related <code>ResultSet</code> is reused.
    * <p>
-   * Default value at initialization is <code>true</code> (<code>ResultSetCollector</code> 
+   * Default value at initialization is <code>true</code> (<code>ResultSetCollector</code>
    * not printed).
    */
   private boolean lastValueReturnedByNext;
   private List<Object> row;
   private List<List<Object>> rows;
   private Map<String, Integer> colNameToColIndex;
-  private int colIndex; 
+  private int colIndex;
   //same getters in JDBC 4.2
-  private static final List<String> GETTERS = Arrays.asList(new String[] {"getArray", 
-          "getAsciiStream", "getBigDecimal", "getBinaryStream", "getBlob", "getBoolean", 
-          "getByte", "getBytes", "getCharacterStream", "getClob", "getDate", "getDouble", 
-          "getFloat", "getInt", "getLong", "getNCharacterStream", "getNClob", "getNString", 
-          "getObject", "getRef", "getRowId", "getShort", "getSQLXML", "getString",  
+  private static final List<String> GETTERS = Arrays.asList(new String[] {"getArray",
+          "getAsciiStream", "getBigDecimal", "getBinaryStream", "getBlob", "getBoolean",
+          "getByte", "getBytes", "getCharacterStream", "getClob", "getDate", "getDouble",
+          "getFloat", "getInt", "getLong", "getNCharacterStream", "getNClob", "getNString",
+          "getObject", "getRef", "getRowId", "getShort", "getSQLXML", "getString",
           "getTime", "getTimestamp", "getUnicodeStream", "getURL"});
 
   public List<List<Object>> getRows() {
@@ -126,8 +126,8 @@ public class DefaultResultSetCollector implements ResultSetCollector {
 	  if (this.loaded) {
 		  return;
 	  }
-	  //otherwise, get all data now, so that we don't need 
-	  //to use the ResultSetMetaData later (with some drivers, 
+	  //otherwise, get all data now, so that we don't need
+	  //to use the ResultSetMetaData later (with some drivers,
 	  //it cannot be used once the ResultSet has been closed)
       try {
     	  if (!rs.isClosed()) {
@@ -138,12 +138,12 @@ public class DefaultResultSetCollector implements ResultSetCollector {
       }
       this.loaded = true;
   }
-  
+
   /**
-   * Perform the operations requested by {@link #loadMetaDataIfNeeded(ResultSet)}, 
+   * Perform the operations requested by {@link #loadMetaDataIfNeeded(ResultSet)},
    * using directly the related <code>ResultSetMetaData</code>.
-   * @param metaData 	The <code>ResultSetMetaData</code> through which the information 
-   * 					needed by {@link #loadMetaDataIfNeeded(ResultSet)} are obtained. 
+   * @param metaData 	The <code>ResultSetMetaData</code> through which the information
+   * 					needed by {@link #loadMetaDataIfNeeded(ResultSet)} are obtained.
    */
   private void loadMetaDataIfNeeded(ResultSetMetaData metaData)
   {
@@ -151,8 +151,8 @@ public class DefaultResultSetCollector implements ResultSetCollector {
 	  if (this.loaded) {
 		  return;
 	  }
-	  //otherwise, get all data now, so that we don't need 
-	  //to use the ResultSetMetaData later (with some drivers, 
+	  //otherwise, get all data now, so that we don't need
+	  //to use the ResultSetMetaData later (with some drivers,
 	  //it cannot be used once the ResultSet has been closed)
       try {
           if (metaData == null) {
@@ -168,13 +168,16 @@ public class DefaultResultSetCollector implements ResultSetCollector {
     		  this.columnNames.put(column, name);
     		  colNameToColIndex.put(label, column);
     		  colNameToColIndex.put(name, column);
-    		  //get also the table name to resolve calls such as: 
+    		  //get also the table name to resolve calls such as:
     		  //rs.getString("myTable.myColumn")
-              String table = metaData.getTableName(column).toLowerCase();
+            String tableName = metaData.getTableName(column);
+            if (tableName != null) {
+              String table = tableName.toLowerCase();
               colNameToColIndex.put(table + "." + name, column);
-              //not sure whether table name can be mixed with column label, 
+              //not sure whether table name can be mixed with column label,
               //but just in case...
               colNameToColIndex.put(table + "." + label, column);
+            }
     	  }
     	  this.loaded = true;
       } catch (SQLException e) {
@@ -185,25 +188,25 @@ public class DefaultResultSetCollector implements ResultSetCollector {
   public String getColumnName(int column) {
       return this.columnNames.get(column);
   }
-  
+
   public String getColumnLabel(int column) {
 	  return this.columnLabels.get(column);
   }
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.sf.log4jdbc.ResultSetCollector#methodReturned(net.sf.log4jdbc.
    * ResultSetSpy, java.lang.String, java.lang.Object, java.lang.Object,
    * java.lang.Object)
    */
   @Override
-  public boolean methodReturned(ResultSetSpy resultSetSpy, String methodCall, Object returnValue, 
-		  Object targetObject, Object... methodParams) 
+  public boolean methodReturned(ResultSetSpy resultSetSpy, String methodCall, Object returnValue,
+		  Object targetObject, Object... methodParams)
   {
-         
+
     if (methodCall.startsWith("get") && methodParams != null && methodParams.length == 1) {
-            
+
       String methodName = methodCall.substring(0, methodCall.indexOf('('));
       if (GETTERS.contains(methodName) && getColumnCount() != 0) {
         setColIndexFromGetXXXMethodParams(methodParams);
@@ -219,13 +222,13 @@ public class DefaultResultSetCollector implements ResultSetCollector {
     if ("next()".equals(methodCall) || "first()".equals(methodCall)) {
     	this.lastValueReturnedByNext = (Boolean) returnValue;
     }
-    if ("next()".equals(methodCall) || "first()".equals(methodCall) || 
+    if ("next()".equals(methodCall) || "first()".equals(methodCall) ||
     		"close()".equals(methodCall)) {
       loadMetaDataIfNeeded(resultSetSpy.getRealResultSet());
-      boolean isEndOfResultSet = 
-    		  //"close" triggers a printing only if the previous call to next 
+      boolean isEndOfResultSet =
+    		  //"close" triggers a printing only if the previous call to next
     		  //did not return false (end of result set already reached)
-    		  ("close()".equals(methodCall) && this.lastValueReturnedByNext != false) || 
+    		  ("close()".equals(methodCall) && this.lastValueReturnedByNext != false) ||
     		  Boolean.FALSE.equals(returnValue) ;
       if (row != null) {
         if (rows == null)
@@ -241,7 +244,7 @@ public class DefaultResultSetCollector implements ResultSetCollector {
 
     if ("getMetaData()".equals(methodCall)) {
       // If the client code calls getMetaData then we don't have to
-      //here we assume that the real ResultSet is not yet closed. 
+      //here we assume that the real ResultSet is not yet closed.
       this.loadMetaDataIfNeeded((ResultSetMetaData) returnValue);
     }
     return false;
@@ -280,7 +283,7 @@ public class DefaultResultSetCollector implements ResultSetCollector {
 
   @Override
   public void preMethod(ResultSetSpy resultSetSpy, String methodCall, Object... methodParams) {
-    if ((methodCall.equals("next()") || methodCall.equals("close()")) && 
+    if ((methodCall.equals("next()") || methodCall.equals("close()")) &&
     		fillInUnreadValues) {
       if (row != null) {
         int colIndex = 0;
@@ -288,7 +291,7 @@ public class DefaultResultSetCollector implements ResultSetCollector {
           if (v != null && v.toString().equals(UNREAD)) {
             Object resultSetValue = null;
             try {
-              // Fill in any unread data 
+              // Fill in any unread data
               resultSetValue = JdbcUtils.getResultSetValue(resultSetSpy.getRealResultSet(),colIndex+1);
             } catch (SQLException e) {
               resultSetValue = UNREAD_ERROR;

--- a/log4jdbc-log4j2-jdbc4.1/src/main/java/net/sf/log4jdbc/sql/resultsetcollector/ResultSetCollectorPrinter.java
+++ b/log4jdbc-log4j2-jdbc4.1/src/main/java/net/sf/log4jdbc/sql/resultsetcollector/ResultSetCollectorPrinter.java
@@ -22,10 +22,10 @@ import java.util.List;
 
 /***
  * @author Tim Azzopardi
- * @author Mathieu Seppey 
- * 
+ * @author Mathieu Seppey
+ *
  * Update : changed printResultSet into getResultSetToPrint
- * 
+ *
  */
 
 public class ResultSetCollectorPrinter {
@@ -46,20 +46,20 @@ public class ResultSetCollectorPrinter {
      * Return a table which represents a <code>ResultSet</code>,
      * to be printed by a logger,
      * based on the content of the provided <code>resultSetCollector</code>.
-     * 
+     *
      * This method will be actually called by a <code>SpyLogDelegator</code>
      * when the <code>next()</code> method of the spied <code>ResultSet</code>
      * return <code>false</code> meaning that its end is reached.
-     * It will be also called if the <code>ResultSet</code> is closed. 
-     * 
-     * 
+     * It will be also called if the <code>ResultSet</code> is closed.
+     *
+     *
      * @param resultSetCollector the ResultSetCollector which has collected the data we want to print
      * @return A <code>String</code> which contains the formatted table to print
-     * 
+     *
      * @see net.sf.log4jdbc.ResultSetSpy
      * @see net.sf.log4jdbc.sql.resultsetcollector.DefaultResultSetCollector
      * @see net.sf.log4jdbc.log.SpyLogDelegator
-     * 
+     *
      */
     public String getResultSetToPrint(ResultSetCollector resultSetCollector) {
 
@@ -69,8 +69,8 @@ public class ResultSetCollectorPrinter {
         int maxLength[] = new int[columnCount];
 
         for (int column = 1; column <= columnCount; column++) {
-            maxLength[column - 1] = resultSetCollector.getColumnName(column)
-                    .length();
+            String columnName = resultSetCollector.getColumnName(column);
+            maxLength[column - 1] = columnName != null ? columnName.length() : 0;
         }
         if (resultSetCollector.getRows() != null) {
             for (List<Object> printRow : resultSetCollector.getRows()) {
@@ -99,9 +99,9 @@ public class ResultSetCollectorPrinter {
         this.table.append(System.getProperty("line.separator"));
         this.table.append("|");
         for (int column = 1; column <= columnCount; column++) {
-            this.table.append(padRight(resultSetCollector.getColumnName(column),
-                    maxLength[column - 1])
-                    + "|");
+            String columnName = resultSetCollector.getColumnName(column);
+            this.table.append(padRight(columnName != null ? columnName : "",
+                maxLength[column - 1]) + "|");
         }
         this.table.append(System.getProperty("line.separator"));
         this.table.append("|");
@@ -133,7 +133,7 @@ public class ResultSetCollectorPrinter {
 
         resultSetCollector.reset();
 
-        return this.table.toString() ;
+        return this.table.toString();
 
     }
 


### PR DESCRIPTION
We recently started seeing a `NullPointerException` in `DefaultResultSetCollector#loadMetaDataIfNeeded` on this line:
```
String table = metaData.getTableName(column).toLowerCase()
```
Here is the relevant stacktrace:
```
java.lang.NullPointerException: null
    at net.sf.log4jdbc.sql.resultsetcollector.DefaultResultSetCollector.loadMetaDataIfNeeded
    at net.sf.log4jdbc.sql.resultsetcollector.DefaultResultSetCollector.loadMetaDataIfNeeded
    at net.sf.log4jdbc.sql.jdbcapi.ResultSetSpy.loadMetaDataIfNeeded
    at net.sf.log4jdbc.sql.jdbcapi.ResultSetSpy.close
    at org.skife.jdbi.v2.Cleanables$ResultSetCleanable.cleanup
    at org.skife.jdbi.v2.BaseStatement$StatementCleaningCustomizer.cleanup
    at org.skife.jdbi.v2.BaseStatement.cleanup
    at org.skife.jdbi.v2.GeneratedKeys.first
    at org.skife.jdbi.v2.sqlobject.ResultReturnThing$SingleValueResultReturnThing.result
    at org.skife.jdbi.v2.sqlobject.UpdateHandler$1.value
    at org.skife.jdbi.v2.sqlobject.UpdateHandler.invoke
    at org.skife.jdbi.v2.sqlobject.SqlObject.invoke
    at org.skife.jdbi.v2.sqlobject.SqlObject$3.intercept
```

I'm not entirely sure what triggered this issue in the first place, it seems like `ResultSetMetaData#getTableName` started returning `null` which caused the NPE. Guarding that block with a null check seems to fix the issue.

Please note that my IDE made other (unrelated) changes to the file due to inconsistent line breaks and trailing spaces. You can ignore that. Actual change is on line 174